### PR TITLE
openvela: add prebuilts/tools for build env

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -229,9 +229,14 @@
   <project path="prebuilts/gcc/linux/arm64" name="openvela-toolchain/prebuilts_gcc_linux-x86_64_aarch64-none-elf"
            remote="git" revision="13.2.rel1" clone-depth="1" />
 
-  <project path="prebuilts/gcc/darwin-aarch64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_darwin-aarch64_x86_64-none-linux-gnu" remote="git" revision="main" clone-depth="1" groups="notdefault,platform-darwin"/>
-  <project path="prebuilts/gcc/linux-aarch64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_linux-aarch64_x86_64-none-linux-gnu" remote="git" revision="main" clone-depth="1" groups="notdefault,platform-linux" />
-  <project path="prebuilts/gcc/linux-x86_64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_linux-x86_64_x86_64-none-linux-gnu" remote="git" revision="main" clone-depth="1" groups="notdefault,platform-linux" />
-  <project path="prebuilts/gcc/windows-x86_64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_windows-x86_64_x86_64-none-linux-gnu" remote="git" revision="main" clone-depth="1" groups="notdefault,platform-windows" />
+  <project path="prebuilts/gcc/darwin-aarch64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_darwin-aarch64_x86_64-none-linux-gnu"
+           remote="git" revision="main" clone-depth="1" groups="notdefault,platform-darwin"/>
+  <project path="prebuilts/gcc/linux-aarch64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_linux-aarch64_x86_64-none-linux-gnu"
+           remote="git" revision="main" clone-depth="1" groups="notdefault,platform-linux" />
+  <project path="prebuilts/gcc/linux-x86_64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_linux-x86_64_x86_64-none-linux-gnu"
+           remote="git" revision="main" clone-depth="1" groups="notdefault,platform-linux" />
+  <project path="prebuilts/gcc/windows-x86_64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_windows-x86_64_x86_64-none-linux-gnu"
+           remote="git" revision="main" clone-depth="1" groups="notdefault,platform-windows" />
+  <project path="prebuilts/tools" name="prebuilts_tools" clone-depth="1" />
 
 </manifest>


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

add prebuilts/tools for open vela env.

## Impact

apply [kconfiglib](https://github.com/open-vela/prebuilts_tools/tree/dev/python/dist-packages/kconfiglib) into openvela code env, no need to download it separately.

https://github.com/open-vela/docs/issues/52

## Testing

PASS Vela CI.

