### PR TITLE
update xtensa-esp32s3-elf path to prebuilts/gcc/linux-x86_64/xtensa-esp32s3-elf

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -238,7 +238,7 @@
            remote="git" revision="main" clone-depth="1" groups="notdefault,platform-linux" />
   <project path="prebuilts/gcc/linux-x86_64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_linux-x86_64_x86_64-none-linux-gnu"
            remote="git" revision="main" clone-depth="1" groups="notdefault,platform-linux" />
-  <project path="prebuilts/gcc/linux-x86_64/xtensa-esp32s3" name="openvela-toolchain-external/prebuilts_gcc_linux-x86_64_xtensa-esp32s3-elf"
+  <project path="prebuilts/gcc/linux-x86_64/xtensa-esp32s3-elf" name="openvela-toolchain-external/prebuilts_gcc_linux-x86_64_xtensa-esp32s3-elf"
            remote="git" revision="main" clone-depth="1" groups="notdefault,platform-linux" />
   <project path="prebuilts/gcc/windows-x86_64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_windows-x86_64_x86_64-none-linux-gnu"
            remote="git" revision="main" clone-depth="1" groups="notdefault,platform-windows" />


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

update xtensa-esp32s3-elf path to prebuilts/gcc/linux-x86_64/xtensa-esp32s3-elf

