### PR TITLE
update prebuilts_gcc_linux-x86_64_aarch64-none-elf/prebuilts_gcc_linux-x86_64_arm-none-eabi use openvela remote

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -227,10 +227,10 @@
            remote="git" revision="13.2.rel1" clone-depth="1"  />
   <project path="prebuilts/gcc/darwin-x86_64/arm64" name="openvela-toolchain/prebuilts_gcc_darwin-x86_64_aarch64-none-elf"
            remote="git" revision="13.2.rel1" clone-depth="1"  />
-  <project path="prebuilts/gcc/linux/arm" name="openvela-toolchain/prebuilts_gcc_linux-x86_64_arm-none-eabi"
-           remote="git" revision="13.2.rel1" clone-depth="1" />
-  <project path="prebuilts/gcc/linux/arm64" name="openvela-toolchain/prebuilts_gcc_linux-x86_64_aarch64-none-elf"
-           remote="git" revision="13.2.rel1" clone-depth="1" />
+  <project path="prebuilts/gcc/linux/arm" name="prebuilts_gcc_linux-x86_64_arm-none-eabi"
+           revision="dev" clone-depth="1" />
+  <project path="prebuilts/gcc/linux/arm64" name="prebuilts_gcc_linux-x86_64_aarch64-none-elf"
+           revision="dev" clone-depth="1" />
 
   <project path="prebuilts/gcc/darwin-aarch64/x86_64-none-linux-gnu" name="openvela-toolchain/prebuilts_gcc_darwin-aarch64_x86_64-none-linux-gnu"
            remote="git" revision="main" clone-depth="1" groups="notdefault,platform-darwin"/>


### PR DESCRIPTION
…x-x86_64_arm-none-eabi use openvela remote

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

update prebuilts_gcc_linux-x86_64_aarch64-none-elf/prebuilts_gcc_linux-x86_64_arm-none-eabi use openvela remote

