### PR TITLE
feat(manifest): add external_bailian_sdk

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -68,6 +68,7 @@
   <project path="external/android/system/tools/hidl" name="external_android_system_tools_hidl" />
   <project path="external/atomic_queue/atomic_queue" name="external_atomic_queue" />
   <project path="external/auto-pts/auto-pts" name="external_auto-pts" />
+  <project path="external/bailian_sdk" name="external_bailian_sdk" />
   <project path="external/avb/avb" name="external_avb" />
   <project path="external/bzip2/bzip2" name="external_bzip2" />
   <project path="external/c-ares/c-ares" name="external_c-ares" />


### PR DESCRIPTION
## Summary

Cherry-pick from dev: Add external_bailian_sdk to openvela.xml manifest.

- Path: `external/bailian_sdk`
- Name: `external_bailian_sdk`

## Impact

New repository mapping added to manifest, no existing entries affected.

## Testing

N/A - manifest change only.