### PR TITLE
feat(manifest): sync openvela.xml for trunk-5.5

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -44,8 +44,9 @@
   <project path="apps/testing/fff/fff" name="apps_testing_fff" />
   <project path="apps/testing/libc-test/libc-test" name="apps_testing_libc-test" />
   <project path="apps/testing/ltp/ltp" name="apps_testing_ltp" />
-  <project path="apps/testing/stressapptest/stressapptest" name="apps_testing_stressapptest" />
+  <project path="apps/testing/mm/stressapptest/stressapptest" name="apps_testing_mm_stressapptest" />
   <project path="apps/testing/unity/Unity" name="apps_testing_unity_Unity" />
+  <project path="build" name="build" />
   <project path="docs" name="docs" />
   <project path="external" name="external" />
   <project path="external/aac/aac" name="external_aac" />
@@ -94,7 +95,7 @@
   <project path="external/iperf2/iperf2" name="external_iperf2" />
   <project path="external/iperf3/iperf3" name="external_iperf3" />
   <project path="external/json-c/json-c" name="external_json-c" />
-  <project path="external/lc3/lc3" name="external_lc3" />
+  <project path="external/liblc3/liblc3" name="external_liblc3" />
   <project path="external/ldns/ldns" name="external_ldns" />
   <project path="external/libchrome/modp_b64" name="external_libchrome_modp_b64" />
   <project path="external/libdivide/libdivide" name="external_libdivide" />
@@ -204,7 +205,7 @@
   <project path="packages/apps" name="packages_apps" />
   <project path="packages/demos" name="packages_demos" />
   <project path="packages/fe/examples" name="packages_fe_examples"/>
-  <project path="prebuilts/clang/linux/wasm" name="prebuilts_clang_linux_wasm" clone-depth="1" />
+  <project path="prebuilts/clang-wasm/linux-x86_64" name="prebuilts_clang_linux_wasm" clone-depth="1" />
   <project path="tests" name="tests" />
   <project path="vendor" name="vendor" />
   <project path="vendor/allwinnertech" name="vendor_allwinnertech" />


### PR DESCRIPTION
Sync openvela.xml for trunk-5.5 release.

## Changes

1. **Rename** `apps/testing/stressapptest/stressapptest` → `apps/testing/mm/stressapptest/stressapptest` (new repo: `apps_testing_mm_stressapptest`)
2. **Rename** `external/lc3/lc3` → `external/liblc3/liblc3` (new repo: `external_liblc3`)
3. **Update** `prebuilts/clang/linux/wasm` path → `prebuilts/clang-wasm/linux-x86_64`
4. **Add** `build` project for cmake build support

## New GitHub repos created

| Repo | Description |
|------|-------------|
| `open-vela/apps_testing_mm_stressapptest` | openvela apps/testing/mm/stressapptest |
| `open-vela/external_liblc3` | openvela external/liblc3 |
| `open-vela/build` | openvela build system |

All 91 cleaned repos have been pushed to GitHub trunk branch.