### PR TITLE
test(ci): validate vendor-based matrix and result aggregation

### DIFF
--- a/.ci-trigger.md
+++ b/.ci-trigger.md
@@ -1,0 +1,9 @@
+# CI trigger for jyliutestci
+
+Trivial file added to open a PR that triggers the jyliutestci CI
+dispatcher. Validates:
+- matrix split by vendor (goldfish / sil / aurix / flagchip / qemu)
+- qemu builds
+- needs.ci-tasks.result aggregation in post-processing
+
+See liujinye-sys/public-actions@test/ci-matrix-by-vendor.


### PR DESCRIPTION
Closing: the jyliutestci dispatcher didn't actually route to the test branch because `open-vela/manifests` uses the default branch (`dev`) dispatcher for `pull_request_target` events, so no real CI ran here.

End-to-end validation was done instead via a self-test workflow inside the fork:
https://github.com/liujinye-sys/public-actions/actions/runs/25424153926

The fix has been applied in:
- `trunk` via open-vela/public-actions#58 (merged)
- `dev` via open-vela/public-actions#59 (open)