### PR TITLE
manifest: add vendor_gigadevice repo

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -214,6 +214,7 @@
   <project path="vendor/bes" name="vendor_bes"/>
   <project path="vendor/espressif" name="vendor_espressif"/>
   <project path="vendor/flagchip" name="vendor_flagchip"/>
+  <project path="vendor/gigadevice" name="vendor_gigadevice"/>
   <project path="vendor/infineon" name="vendor_infineon"/>
   <project path="vendor/infineon/chips/aurix/illd" name="vendor_infineon_chips_aurix_illd"/>
   <project path="vendor/infineon/chips/aurix/illd/tc4x/Libraries" name="vendor_infineon_chips_aurix_illd_tc4x_Libraries"/>


### PR DESCRIPTION
## Summary

Add vendor_gigadevice repository to openvela manifest:
- `vendor/gigadevice` - GigaDevice (GD) chip vendor code for openvela

Entry is inserted in alphabetical order between `vendor_flagchip` and `vendor_infineon`.

## Impact

New repo will be synced when running `repo sync`.

## Testing

Verified XML is well-formed and entry is in correct alphabetical position.