### PR TITLE
manifest: add vendor_artinchip repo

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -212,6 +212,7 @@
   <project path="tests" name="tests" />
   <project path="vendor" name="vendor" />
   <project path="vendor/allwinnertech" name="vendor_allwinnertech" />
+  <project path="vendor/artinchip" name="vendor_artinchip" />
   <project path="vendor/bes" name="vendor_bes" />
   <project path="vendor/espressif" name="vendor_espressif" />
   <project path="vendor/flagchip" name="vendor_flagchip" />


### PR DESCRIPTION
## Summary

Add vendor_artinchip repository to openvela manifest for ArtInChip chip support.

- vendor/artinchip - ArtInChip vendor BSP code

Entry is inserted in alphabetical order between vendor_allwinnertech and vendor_bes.

## Impact

New repo will be synced when running repo sync.

## Testing

Verified XML is well-formed and entry is in correct alphabetical position.