### PR TITLE
feat: add vendor_st to manifest (dev-ai-contest-2026)

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -224,6 +224,7 @@
   <project path="vendor/openvela/boards/sil" name="vendor_openvela_boards_sil"/>
   <project path="vendor/gravityxr" name="vendor_gravityxr"/>
   <project path="vendor/sifli" name="vendor_sifli"/>
+  <project path="vendor/st" name="vendor_st"/>
   <project path="vendor/template" name="vendor_template"/>
   <project path="vendor/xiaomi" name="vendor_xiaomi"/>
   <project path="vendor/xiaomi/vela" name="vendor_xiaomi_vela"/>


### PR DESCRIPTION
## Summary
Add `vendor_st` (STMicroelectronics vendor support) to `openvela.xml` manifest.

```xml
<project path="vendor/st" name="vendor_st"/>
```

Inserted after `vendor_sifli` in alphabetical order.

## Related
- GitHub repo: https://github.com/open-vela/vendor_st
- Team `dev-ai-contest-reviewer` granted push permission
- CODEOWNERS on `dev-ai-contest-2026` branch set to `@open-vela/dev-ai-contest-reviewer`