### PR TITLE
feat: add vendor_st repository to manifest (trunk)

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -226,6 +226,7 @@
   <project path="vendor/openvela/boards/sil" name="vendor_openvela_boards_sil" />
   <project path="vendor/gravityxr" name="vendor_gravityxr" />
   <project path="vendor/sifli" name="vendor_sifli" />
+  <project path="vendor/st" name="vendor_st" />
   <project path="vendor/template" name="vendor_template" />
   <project path="vendor/xiaomi" name="vendor_xiaomi" />
   <project path="vendor/xiaomi/vela" name="vendor_xiaomi_vela" />


### PR DESCRIPTION
## Summary
Add the new `vendor_st` (STMicroelectronics) repository to `openvela.xml`.

```
+ <project path="vendor/st" name="vendor_st" />
```

Inserted in the vendor section after `vendor/sifli`, matching the self-closing tag style used on this branch.

## Notes
- The `vendor_st` repo has been created on GitHub and Gitee with `dev` / `trunk` / `dev-ai-contest-2026` branches.
- This PR targets the `trunk` branch.