### PR TITLE
manifest: add vendor_SpacemiT project (dev)

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -227,6 +227,7 @@
   <project path="vendor/gravityxr" name="vendor_gravityxr"/>
   <project path="vendor/rockchip" name="vendor_rockchip"/>
   <project path="vendor/sifli" name="vendor_sifli"/>
+  <project path="vendor/SpacemiT" name="vendor_SpacemiT"/>
   <project path="vendor/st" name="vendor_st"/>
   <project path="vendor/template" name="vendor_template"/>
   <project path="vendor/xiaomi" name="vendor_xiaomi"/>


### PR DESCRIPTION
Add `vendor_SpacemiT` project to `openvela.xml` for managing SpacemiT (进迭时空) chip vendor code.

- path: `vendor/SpacemiT`
- name: `vendor_SpacemiT`
- Inserted between `vendor/sifli` and `vendor/st` (alphabetical order).

Repo: https://github.com/open-vela/vendor_SpacemiT