### PR TITLE
manifest: add libs_sifli_sf32lb52 prebuilt libraries

### DIFF
--- a/openvela.xml
+++ b/openvela.xml
@@ -228,6 +228,7 @@
   <project path="vendor/gravityxr" name="vendor_gravityxr" />
   <project path="vendor/rockchip" name="vendor_rockchip" />
   <project path="vendor/sifli" name="vendor_sifli" />
+  <project path="vendor/sifli/boards/sf32lb52/libs" name="libs_sifli_sf32lb52" />
   <project path="vendor/SpacemiT" name="vendor_SpacemiT" />
   <project path="vendor/st" name="vendor_st" />
   <project path="vendor/template" name="vendor_template" />


### PR DESCRIPTION
Add the sifli sf32lb52 prebuilt libraries repo (`libs_sifli_sf32lb52`) to `openvela.xml`, mapped at `vendor/sifli/boards/sf32lb52/libs`. Mainly used for the sifli quickapp output, mirroring `libs_openvela_vela`.

The community repo has been created and pushed:
- GitHub: https://github.com/open-vela/libs_sifli_sf32lb52
- Gitee: https://gitee.com/open-vela/libs_sifli_sf32lb52